### PR TITLE
Added a gradle property to ensure it to function on mac osx

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx1024M


### PR DESCRIPTION
The gradle tasks "setupDecompWorkspace" have a tendency to fail if this property have not been set.
