### PR TITLE
Creative Tab overrides getTranslatedTabLabel and would make Lex sad

### DIFF
--- a/src/main/java/com/pahimar/letsmodreboot/creativetab/CreativeTabLMRB.java
+++ b/src/main/java/com/pahimar/letsmodreboot/creativetab/CreativeTabLMRB.java
@@ -14,11 +14,5 @@ public class CreativeTabLMRB
         {
             return ModItems.mapleLeaf;
         }
-
-        @Override
-        public String getTranslatedTabLabel()
-        {
-            return "Let's Mod Reboot";
-        }
     };
 }

--- a/src/main/resources/assets/letsmodreboot/lang/en_US.lang
+++ b/src/main/resources/assets/letsmodreboot/lang/en_US.lang
@@ -1,2 +1,3 @@
 item.letsmodreboot:mapleLeaf.name=Maple Leaf of Awesomeness
 tile.letsmodreboot:flag.name=Canadian Flag of Awesomeness
+itemGroup.letsmodreboot.name=Let's Mod Reboot

--- a/src/main/resources/assets/letsmodreboot/lang/en_US.lang
+++ b/src/main/resources/assets/letsmodreboot/lang/en_US.lang
@@ -1,3 +1,3 @@
 item.letsmodreboot:mapleLeaf.name=Maple Leaf of Awesomeness
 tile.letsmodreboot:flag.name=Canadian Flag of Awesomeness
-itemGroup.letsmodreboot.name=Let's Mod Reboot
+itemGroup.letsmodreboot=Let's Mod Reboot


### PR DESCRIPTION
It's not best practice to hard code localization stuff, when you have a lang file. `getTranslatedTabLabel()` should be removed, and `itemGroup.letsmodreboot.name=Let's Mod Reboot` should be added to the lang file.
